### PR TITLE
Disable SSL verification for erajyapatra.karnataka.gov.in

### DIFF
--- a/srcs/karnataka.py
+++ b/srcs/karnataka.py
@@ -99,6 +99,12 @@ class KarnatakaErajyapatra(BaseGazette):
         self.baseurl      = 'https://erajyapatra.karnataka.gov.in/'
         self.start_date   = datetime.datetime(2020, 1, 1)
         self.result_table = 'ContentPlaceHolder1_dgGeneralUser'
+        
+    def get_session(self):
+        # Override to disable SSL verification
+        s = super().get_session()
+        s.verify = False
+        return s
 
 
     def pop_field(self, postdata, field):


### PR DESCRIPTION
Karnataka Gazette archiver has been silently failing due to an invalid certificate chain on erajyapatra.karnataka.gov.in: https://github.com/ramSeraph/egazette/actions/runs/19275815741/job/55115240775#step:3:446

This PR disables SSL verification for the `requests` library used by `KarnatakaErajyapatra`

The invalid certificate chain:

```
> openssl s_client -showcerts -servername erajyapatra.karnataka.gov.in -connect erajyapatra.karnataka.gov.in:443
Connecting to 103.138.197.98
CONNECTED(00000005)
depth=0 CN=erajyapatra.karnataka.gov.in
verify error:num=20:unable to get local issuer certificate
verify return:1
depth=0 CN=erajyapatra.karnataka.gov.in
verify error:num=21:unable to verify the first certificate
verify return:1
depth=0 CN=erajyapatra.karnataka.gov.in
verify return:1
```